### PR TITLE
Add new guideline: use 'other' value to ignore a field

### DIFF
--- a/index.html
+++ b/index.html
@@ -860,6 +860,12 @@ href="#biblio-html">[html]</a> specification: the <code>data-form-type</code>
         <li>the <strong><code>gender</code></strong> extra value indicates
           gender information</li>
       </ul>
+      <div class="def">
+        <h4 class="no-num no-toc no-ref heading settled">Use the "other" value
+          to ignore a field</h4>
+        <p>Should you need to make a form field "ignored" by client codes, you
+          can set its <code>data-form-type</code> attribute to "<code>other</code>".</p>
+      </div>
       <h4 class="no-num no-toc no-ref"><a id="mozTocId677767" class="mozTocH4"></a>Examples</h4>
       <div class="example">
         <p>Subscription page for the Washington Post in April 2020:</p>


### PR DESCRIPTION
Closes Issue #1 and adds a new guidline for `data-form-type="other"` to ignore a form field.